### PR TITLE
Update Makefile add include location to prevent make failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ CPPFLAGS += -MD -MP
 CPPFLAGS += -g -O2 
 
 # Weird stuff needed to do OpenGL ES 2 on a Raspberry Pi
-CPPFLAGS += -I/opt/vc/include -I/opt/vc/include/interface/vcos/pthreads
+CPPFLAGS += -I/opt/vc/include -I/opt/vc/include/interface/vcos/pthreads -I/opt/vc/include/interface/vmcs_host/linux
 LDFLAGS += -L/opt/vc/lib -lGLESv2
 
 # Tell the cpp file where assets are stored.


### PR DESCRIPTION
Update Makefile add include location for CPPFLAGS to avoid failure when vchost_config.h is not found
